### PR TITLE
Fix Windows related issues

### DIFF
--- a/pyknp/juman/juman.py
+++ b/pyknp/juman/juman.py
@@ -45,8 +45,8 @@ class Juman(object):
         self.subprocess = None
         if self.rcfile and not os.path.isfile(os.path.expanduser(self.rcfile)):
             raise Exception("Can't read rcfile (%s)!" % self.rcfile)
-        if distutils.spawn.find_executable(command) is None:
-            raise Exception("Can't find JUMAN command: %s" % command)
+        if distutils.spawn.find_executable(self.command) is None:
+            raise Exception("Can't find JUMAN command: %s" % self.command)
 
     def juman_lines(self, input_str):
         """ 入力文字列に対して形態素解析を行い、そのJuman出力結果を返す

--- a/pyknp/juman/juman.py
+++ b/pyknp/juman/juman.py
@@ -34,7 +34,7 @@ class Juman(object):
             self.option = option
         else:
             self.command = 'juman'
-            self.option = option+' -e2 -B'
+            self.option = option.split() + ['-e2', '-B']
         self.server = server
         self.port = port
         self.timeout = timeout
@@ -64,9 +64,9 @@ class Juman(object):
             if self.server is not None:
                 self.socket = Socket(self.server, self.port, "RUN -e2\n")
             else:
-                command = "%s %s" % (self.command, self.option)
+                command = [self.command] + self.option
                 if 'jumanpp' not in self.command and self.rcfile:
-                    command += " -r %s" % self.rcfile
+                    command.extend(['-r', self.rcfile])
                 self.subprocess = Subprocess(command)
         if self.socket:
             return self.socket.query(input_str, pattern=self.pattern)

--- a/pyknp/juman/process.py
+++ b/pyknp/juman/process.py
@@ -67,7 +67,7 @@ class Subprocess(object):
         self.process.stdin.flush()
         result = ""
         while True:
-            line = self.stdouterr.readline()[:-1].decode('utf-8')
+            line = self.stdouterr.readline().rstrip().decode('utf-8')
             if re.search(pattern, line):
                 break
             result = "%s%s\n" % (result, line)

--- a/pyknp/juman/process.py
+++ b/pyknp/juman/process.py
@@ -42,8 +42,7 @@ class Subprocess(object):
                 'close_fds': sys.platform != "win32"}
         try:
             env = os.environ.copy()
-            self.process = subprocess.Popen('bash -c "%s"' % command, env=env,
-                                            shell=True, **subproc_args)
+            self.process = subprocess.Popen(command, env=env, **subproc_args)
         except OSError:
             raise
         (self.stdouterr, self.stdin) = (self.process.stdout, self.process.stdin)

--- a/pyknp/knp/knp.py
+++ b/pyknp/knp/knp.py
@@ -43,8 +43,8 @@ class KNP(object):
 
         if self.rcfile and not os.path.isfile(os.path.expanduser(self.rcfile)):
             raise Exception("Can't read rcfile (%s)!" % self.rcfile)
-        if distutils.spawn.find_executable(command) is None:
-            raise Exception("Can't find KNP command: %s" % command)
+        if distutils.spawn.find_executable(self.command) is None:
+            raise Exception("Can't find KNP command: %s" % self.command)
 
         self.juman = Juman(command=jumancommand, rcfile=jumanrcfile, jumanpp=self.jumanpp)
 

--- a/pyknp/knp/knp.py
+++ b/pyknp/knp/knp.py
@@ -34,7 +34,7 @@ class KNP(object):
         self.server = server
         self.port = port
         self.timeout = timeout
-        self.option = option
+        self.option = option.split()
         self.rcfile = rcfile
         self.pattern = pattern
         self.socket = None
@@ -70,9 +70,9 @@ class KNP(object):
                 self.socket = Socket(
                     self.server, self.port, "RUN -tab -normal\n")
             else:
-                command = "%s %s" % (self.command, self.option)
+                command = [self.command] + self.option
                 if self.rcfile:
-                    command += " -r %s" % self.rcfile
+                    command.extend(['-r', self.rcfile])
                 self.subprocess = Subprocess(command)
 
         if self.socket:


### PR DESCRIPTION
I fixed some Windows related issues:

1. Ignored `jumanpp` argument (though it is not an issue only for Windows):
    `jumanpp` (not `juman`)  was searched even if `jumanpp=False` was passed.
2. A requirement of `bash`:
    `bash` was required to execute external commands such as `juman`, but `bash` is not installed by default on Windows.
3. Not removed carriage return (CR):
     One newline character is removed in `Subprocess.query`, but on Windows, two newline characters (CRLF) exist, and the CR was not removed.
