### PR TITLE
Fixed to parse the case info correctly when midasi is ";", closes #26

### DIFF
--- a/pyknp/knp/pas.py
+++ b/pyknp/knp/pas.py
@@ -185,7 +185,8 @@ class Pas(object):
                 i += 1
                 continue
 
-            # 表記が「;」の場合、次の格要素を結合して処理し直す
+            # 表記が「;」の格要素は表記部を境に2つの格要素に分割されてしまう
+            # 従って、このような格要素については次の格要素を結合した上でもう一度処理し直す
             if len(items) == 3:
                 cases[i] += separate_str + cases.pop(i + 1)
                 continue

--- a/pyknp/knp/pas.py
+++ b/pyknp/knp/pas.py
@@ -181,14 +181,14 @@ class Pas(object):
             items = cases[i].split("/")
             caseflag = items[1]
 
-            if caseflag == "U" or caseflag == "-":
-                i += 1
-                continue
-
             # 表記が「;」の格要素は表記部を境に2つの格要素に分割されてしまう
             # 従って、このような格要素については次の格要素を結合した上でもう一度処理し直す
             if len(items) == 3:
                 cases[i] += separate_str + cases.pop(i + 1)
+                continue
+
+            if caseflag == "U" or caseflag == "-":
+                i += 1
                 continue
 
             yield self.__parse_case_info_format(items, case_info_format)

--- a/pyknp/knp/pas.py
+++ b/pyknp/knp/pas.py
@@ -187,11 +187,9 @@ class Pas(object):
                 cases[i] += separate_str + cases.pop(i + 1)
                 continue
 
-            if caseflag == "U" or caseflag == "-":
-                i += 1
-                continue
+            if caseflag != "U" and caseflag != "-":
+                yield self.__parse_case_info_format(items, case_info_format)
 
-            yield self.__parse_case_info_format(items, case_info_format)
             i += 1
 
 

--- a/pyknp/knp/pas.py
+++ b/pyknp/knp/pas.py
@@ -173,12 +173,25 @@ class Pas(object):
             self.valid = False
             return
 
-        for k in analysis_result[c1 + 1:].split(';'):
-            items = k.split("/")
+        separate_str = ';'
+        cases = analysis_result[c1 + 1:].split(separate_str)
+        i = 0
+
+        while i < len(cases):
+            items = cases[i].split("/")
             caseflag = items[1]
+
             if caseflag == "U" or caseflag == "-":
+                i += 1
                 continue
+
+            # 表記が「;」の場合、次の格要素を結合して処理し直す
+            if len(items) == 3:
+                cases[i] += separate_str + cases.pop(i + 1)
+                continue
+
             yield self.__parse_case_info_format(items, case_info_format)
+            i += 1
 
 
     def __set_args(self, analysis_result, case_info_format):


### PR DESCRIPTION
ref. #26 

I fixed to parse the case info (格解析結果) collectly when it contains a case element with midasi `;`.