### PR TITLE
Language analysis by Juman yields an unnecessary morpheme, EOS.

### DIFF
--- a/pyknp/juman/process.py
+++ b/pyknp/juman/process.py
@@ -78,9 +78,9 @@ class Subprocess(object):
             self.process.stdin.flush()
             while True:
                 line = self.process.stdout.readline().decode('utf-8').rstrip()
-                result += line + '\n'
                 if re.search(pattern, line):
                     break
+                result += line + '\n'
         finally:
             signal.alarm(0)
         self.process.stdout.flush()


### PR DESCRIPTION
## What

Language analysis by Juman yields an unnecessary morpheme, EOS.

## Environment

- Juman++: 2.0.0-rc3
- pyknp: the current HEAD of master (https://github.com/ku-nlp/pyknp/commit/38469c8939d171aa9006788eb75eb518bdddd20f)
- Python: 3.8.5
- OS: macOS Bug Sur (11.1)

## To reproduce

```python
>>> from pyknp import Juman
>>> juman = Juman()
>>> r = juman.analysis('テスト')
>>> [m.midasi for m in r.mrph_list()]
['テスト', 'EOS']
```

## To fix

Restore the behavior of Juman's subprocess handler, which had been changed by the latest commit (38469c8939d171aa9006788eb75eb518bdddd20f), so that it returns language analysis results without EOS lines.