### PR TITLE
fix script path and optparse->argparse

### DIFF
--- a/pyknp/scripts/knp_drawtree.py
+++ b/pyknp/scripts/knp_drawtree.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import codecs
-import optparse
+import argparse
 import pyknp
 import six
 import sys
@@ -68,12 +68,23 @@ def draw_trees(inf, outf, lattice_format):
 
 
 def main():
-    oparser = optparse.OptionParser()
-    oparser.add_option("-i", "--input", dest="input", default="-")
-    oparser.add_option("-o", "--output", dest="output", default="-")
-    oparser.add_option("--lattice_format", dest="lattice_format",
-                       action="store_true", default=False)
-    (opts, args) = oparser.parse_args()
+    epilog = '''
+             try:
+             `echo これはテストです。 | jumanpp |
+             knp -tab -anaphora | knp-drawtree`
+             '''
+    aparser = argparse.ArgumentParser(
+        prog='knp-drawtree',
+        description='draw a parse tree from output of knp command',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        epilog=epilog)
+    aparser.add_argument("-i", "--input", default="-",
+                         help="input source")
+    aparser.add_argument("-o", "--output", default="-",
+                         help="output destination")
+    aparser.add_argument("-L", "--lattice_format", action="store_true",
+                         help="output in lattice format")
+    (opts, args) = aparser.parse_args()
 
     if opts.input == "-":
         inf = sys.stdin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ recommonmark = "^0.7"
 sphinx-rtd-theme = "^0.5"
 
 [tool.poetry.scripts]
-knp-drawtree = 'pyknp.scripts:main'
+knp-drawtree = 'pyknp.scripts.knp_drawtree:main'
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
`pyknp/scripts/knp-drawtree`関連のFixです。
`pyproject.toml`の`tool.poetry.scripts`にある`knp-drawtree`が指していたパスが切れていたため`knp-drawtree`が`pip install .`した際使えなくなっていたのを修正しました。
またコマンドラインオプションのパーサライブラリをpython 3.2で非推奨になったoptparseからargparseに切り替え、Help文の追加を行いました。

```
$ git clone https://github.com/eggplants/pyknp
$ cd pyknp
$ pip install .
...
$ knp-drawtree -h
usage: knp-drawtree [-h] [-i INPUT] [-o OUTPUT] [-L]

draw a parse tree from output of knp command

optional arguments:
  -h, --help            show this help message and exit
  -i INPUT, --input INPUT
                        input source (default: -)
  -o OUTPUT, --output OUTPUT
                        output destination (default: -)
  -L, --lattice_format  output in lattice format (default: False)

try: `echo これはテストです。 | jumanpp | knp -tab -anaphora | knp-drawtree`
$
```